### PR TITLE
Address xref output

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,8 +5,11 @@
         debug_info,
         warnings_as_errors
 ]}.
+
 {deps, [
         {cowlib, "1.3.0"},
         {dlhttpc, ".*", {git, "git://github.com/ferd/dlhttpc.git", {branch, "master"}}},
         {jsx, "2.8.2"}
 ]}.
+
+{xref_ignores, [{manta_handler,behaviour_info,1}]}.

--- a/src/manta.erl
+++ b/src/manta.erl
@@ -14,89 +14,173 @@
 -include_lib("public_key/include/public_key.hrl").
 
 %% API exports
+
 %%% Directories
--export([delete_directory/1]).
--export([delete_directory/2]).
--export([delete_directory/3]).
--export([list_directory/0]).
--export([list_directory/1]).
--export([list_directory/2]).
--export([list_directory/3]).
--export([put_directory/1]).
--export([put_directory/2]).
--export([put_directory/3]).
+-export([delete_directory/1,
+		 delete_directory/2,
+		 delete_directory/3,
+		 list_directory/0,
+		 list_directory/1,
+		 list_directory/2,
+		 list_directory/3,
+		 put_directory/1,
+		 put_directory/2,
+		 put_directory/3]).
+
+-ignore_xref({delete_directory,1}).
+-ignore_xref({delete_directory,2}).
+-ignore_xref({delete_directory,3}).
+-ignore_xref({list_directory,0}).
+-ignore_xref({list_directory,1}).
+-ignore_xref({list_directory,2}).
+-ignore_xref({list_directory,3}).
+-ignore_xref({put_directory,1}).
+-ignore_xref({put_directory,2}).
+-ignore_xref({put_directory,3}).
+
 %%% Objects
--export([delete_object/1]).
--export([delete_object/2]).
--export([delete_object/3]).
--export([get_metadata/1]).
--export([get_metadata/2]).
--export([get_metadata/3]).
--export([get_object/1]).
--export([get_object/2]).
--export([get_object/3]).
--export([object_path/1]).
--export([object_path/2]).
--export([object_path/3]).
--export([object_url/1]).
--export([object_url/2]).
--export([object_url/3]).
--export([put_metadata/2]).
--export([put_metadata/3]).
--export([put_metadata/4]).
--export([put_object/2]).
--export([put_object/3]).
--export([put_object/4]).
+-export([delete_object/1,
+		 delete_object/2,
+		 delete_object/3,
+		 get_metadata/1,
+		 get_metadata/2,
+		 get_metadata/3,
+		 get_object/1,
+		 get_object/2,
+		 get_object/3,
+		 object_path/1,
+		 object_path/2,
+		 object_path/3,
+		 object_url/1,
+		 object_url/2,
+		 object_url/3,
+		 put_metadata/2,
+		 put_metadata/3,
+		 put_metadata/4,
+		 put_object/2,
+		 put_object/3,
+		 put_object/4]).
+
+-ignore_xref({delete_object,1}).
+-ignore_xref({delete_object,2}).
+-ignore_xref({delete_object,3}).
+-ignore_xref({get_metadata,1}).
+-ignore_xref({get_metadata,2}).
+-ignore_xref({get_metadata,3}).
+-ignore_xref({get_object,1}).
+-ignore_xref({get_object,2}).
+-ignore_xref({get_object,3}).
+-ignore_xref({object_path,1}).
+-ignore_xref({object_path,2}).
+-ignore_xref({object_path,3}).
+-ignore_xref({object_url,1}).
+-ignore_xref({object_url,2}).
+-ignore_xref({object_url,3}).
+-ignore_xref({put_metadata,2}).
+-ignore_xref({put_metadata,3}).
+-ignore_xref({put_metadata,4}).
+-ignore_xref({put_object,2}).
+-ignore_xref({put_object,3}).
+-ignore_xref({put_object,4}).
+
 %%% SnapLinks
--export([put_snaplink/2]).
--export([put_snaplink/3]).
--export([put_snaplink/4]).
+-export([put_snaplink/2,
+		 put_snaplink/3,
+		 put_snaplink/4]).
+
+-ignore_xref({put_snaplink,2}).
+-ignore_xref({put_snaplink,3}).
+-ignore_xref({put_snaplink,4}).
+
 %%% Jobs
--export([add_job_inputs/2]).
--export([add_job_inputs/3]).
--export([add_job_inputs/4]).
--export([cancel_job/1]).
--export([cancel_job/2]).
--export([cancel_job/3]).
--export([create_job/1]).
--export([create_job/2]).
--export([create_job/3]).
--export([end_job_input/1]).
--export([end_job_input/2]).
--export([end_job_input/3]).
--export([get_job/1]).
--export([get_job/2]).
--export([get_job/3]).
--export([get_job_errors/1]).
--export([get_job_errors/2]).
--export([get_job_errors/3]).
--export([get_job_failures/1]).
--export([get_job_failures/2]).
--export([get_job_failures/3]).
--export([get_job_input/1]).
--export([get_job_input/2]).
--export([get_job_input/3]).
--export([get_job_output/1]).
--export([get_job_output/2]).
--export([get_job_output/3]).
--export([list_jobs/0]).
--export([list_jobs/1]).
--export([list_jobs/2]).
+-export([add_job_inputs/2,
+		 add_job_inputs/3,
+		 add_job_inputs/4,
+		 cancel_job/1,
+		 cancel_job/2,
+		 cancel_job/3,
+		 create_job/1,
+		 create_job/2,
+		 create_job/3,
+		 end_job_input/1,
+		 end_job_input/2,
+		 end_job_input/3,
+		 get_job/1,
+		 get_job/2,
+		 get_job/3,
+		 get_job_errors/1,
+		 get_job_errors/2,
+		 get_job_errors/3,
+		 get_job_failures/1,
+		 get_job_failures/2,
+		 get_job_failures/3,
+		 get_job_input/1,
+		 get_job_input/2,
+		 get_job_input/3,
+		 get_job_output/1,
+		 get_job_output/2,
+		 get_job_output/3,
+		 list_jobs/0,
+		 list_jobs/1,
+		 list_jobs/2]).
+
+-ignore_xref({add_job_inputs,2}).
+-ignore_xref({add_job_inputs,3}).
+-ignore_xref({add_job_inputs,4}).
+-ignore_xref({cancel_job,1}).
+-ignore_xref({cancel_job,2}).
+-ignore_xref({cancel_job,3}).
+-ignore_xref({create_job,1}).
+-ignore_xref({create_job,2}).
+-ignore_xref({create_job,3}).
+-ignore_xref({end_job_input,1}).
+-ignore_xref({end_job_input,2}).
+-ignore_xref({end_job_input,3}).
+-ignore_xref({get_job,1}).
+-ignore_xref({get_job,2}).
+-ignore_xref({get_job,3}).
+-ignore_xref({get_job_errors,1}).
+-ignore_xref({get_job_errors,2}).
+-ignore_xref({get_job_errors,3}).
+-ignore_xref({get_job_failures,1}).
+-ignore_xref({get_job_failures,2}).
+-ignore_xref({get_job_failures,3}).
+-ignore_xref({get_job_input,1}).
+-ignore_xref({get_job_input,2}).
+-ignore_xref({get_job_input,3}).
+-ignore_xref({get_job_output,1}).
+-ignore_xref({get_job_output,2}).
+-ignore_xref({get_job_output,3}).
+-ignore_xref({list_jobs,0}).
+-ignore_xref({list_jobs,1}).
+-ignore_xref({list_jobs,2}).
 
 %% Config API exports
--export([configure/1]).
--export([default_config/0]).
--export([new/1]).
--export([update/1]).
--export([user_agent/0]).
+-export([configure/1,
+		 default_config/0,
+		 new/1,
+		 update/1,
+		 user_agent/0]).
+
+-ignore_xref({configure,1}).
+-ignore_xref({default_config,0}).
+-ignore_xref({new,1}).
+-ignore_xref({update,1}).
+-ignore_xref({user_agent,0}).
 
 %% Utility API
--export([require/1]).
--export([start/0]).
--export([take_value/3]).
+-export([require/1,
+		 start/0,
+		 take_value/3]).
+
+-ignore_xref({require,1}).
+-ignore_xref({start,0}).
+-ignore_xref({take_value,3}).
 
 %% Internal API
 -export([get_value/3]).
+
+-ignore_xref({get_value,3}).
 
 %%====================================================================
 %% API functions

--- a/src/manta_client.erl
+++ b/src/manta_client.erl
@@ -16,6 +16,8 @@
 -export([request/6]).
 -export([init/7]).
 
+-ignore_xref({init,7}).
+
 -record(request, {
 	attempts   = undefined :: undefined | pos_integer(),
 	a_timeout  = undefined :: undefined | timeout(),

--- a/src/manta_directory.erl
+++ b/src/manta_directory.erl
@@ -14,26 +14,18 @@
 -include("manta.hrl").
 
 %% manta_handler callbacks
--export([init/3]).
--export([handle_response/2]).
--export([handle_download/2]).
--export([terminate/1]).
+-export([init/3,
+		 handle_response/2,
+		 handle_download/2,
+		 terminate/1]).
 
 %% API exports
--export([delete/1]).
--export([delete/2]).
--export([delete/3]).
--export([head/0]).
--export([head/1]).
--export([head/2]).
--export([head/3]).
--export([list/0]).
--export([list/1]).
--export([list/2]).
--export([list/3]).
--export([put/1]).
--export([put/2]).
--export([put/3]).
+-export([delete/3,
+		 head/3,
+		 list/3,
+		 put/3]).
+
+-ignore_xref({head,3}).
 
 -define(MAX_LIMIT, 1000).
 
@@ -91,26 +83,11 @@ terminate(#state{default=Default}) ->
 %% API functions
 %%====================================================================
 
-delete(Pathname) ->
-	?MODULE:delete(Pathname, []).
-
-delete(Pathname, Options) ->
-	?MODULE:delete(manta:default_config(), Pathname, Options).
-
 delete(Config=#manta_config{}, Pathname, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
 	{Timeout, Opts2} = manta:take_value(timeout, Opts1, Config#manta_config.timeout),
 	Path = manta_httpc:make_path(Pathname, []),
 	manta_httpc:request(Config, Path, delete, Headers, [], Timeout, Opts2).
-
-head() ->
-	?MODULE:head(<<>>).
-
-head(Pathname) ->
-	?MODULE:head(Pathname, []).
-
-head(Pathname, Options) ->
-	?MODULE:head(manta:default_config(), Pathname, Options).
 
 head(Config=#manta_config{}, Pathname, Opts0) ->
 	{Limit, Opts1} = manta:take_value(limit, Opts0, ?MAX_LIMIT),
@@ -120,15 +97,6 @@ head(Config=#manta_config{}, Pathname, Opts0) ->
 	Path = manta_httpc:make_path(Pathname, [{limit, Limit}, {marker, Marker}]),
 	manta_httpc:request(Config, Path, head, Headers, [], Timeout, Opts4).
 
-list() ->
-	?MODULE:list(<<>>).
-
-list(Pathname) ->
-	?MODULE:list(Pathname, []).
-
-list(Pathname, Options) ->
-	?MODULE:list(manta:default_config(), Pathname, Options).
-
 list(Config=#manta_config{}, Pathname, Opts0) ->
 	{Limit, Opts1} = manta:take_value(limit, Opts0, ?MAX_LIMIT),
 	{Marker, Opts2} = manta:take_value(marker, Opts1, undefined),
@@ -136,12 +104,6 @@ list(Config=#manta_config{}, Pathname, Opts0) ->
 	{Timeout, Opts4} = manta:take_value(timeout, Opts3, Config#manta_config.timeout),
 	Path = manta_httpc:make_path(Pathname, [{limit, Limit}, {marker, Marker}]),
 	manta_httpc:request(Config, Path, get, Headers, [], Timeout, Opts4).
-
-put(Pathname) ->
-	?MODULE:put(Pathname, []).
-
-put(Pathname, Options) ->
-	?MODULE:put(manta:default_config(), Pathname, Options).
 
 put(Config=#manta_config{}, Pathname, Opts0) ->
 	{Headers0, Opts1} = manta:take_value(headers, Opts0, []),

--- a/src/manta_httpc.erl
+++ b/src/manta_httpc.erl
@@ -13,26 +13,34 @@
 -include("manta.hrl").
 
 %% HTTP API exports
--export([request/6]).
--export([request/7]).
--export([send_body_part/2]).
--export([send_body_part/3]).
--export([send_trailers/2]).
--export([send_trailers/3]).
+-export([request/6,
+		 request/7,
+		 send_body_part/2,
+		 send_body_part/3,
+		 send_trailers/2,
+		 send_trailers/3]).
+
+-ignore_xref({request,6}).
+-ignore_xref({send_body_part,3}).
+-ignore_xref({send_trailers,2}).
+-ignore_xref({send_trailers,3}).
 
 %% API exports
--export([account_headers/1]).
--export([account_headers/2]).
--export([make_path/2]).
--export([prepend_account_path/1]).
--export([prepend_account_path/2]).
--export([role_path/1]).
--export([role_path/2]).
--export([role_path/3]).
--export([urlencode_path/1]).
--export([user_path/1]).
--export([user_path/2]).
--export([user_path/3]).
+-export([%% account_headers/1,
+		 %% account_headers/2,
+		 make_path/2,
+		 %% prepend_account_path/1,
+		 %% prepend_account_path/2,
+		 %% role_path/1,
+		 role_path/2,
+		 role_path/3,
+		 %% urlencode_path/1,
+		 %% user_path/1,
+		 %% user_path/2,
+		 user_path/3]).
+
+-ignore_xref({role_path,2}).
+-ignore_xref({role_path,3}).
 
 %%====================================================================
 %% HTTP API functions
@@ -94,9 +102,6 @@ send_trailers({Pid, Window}, Trailers, Timeout) ->
 %% API functions
 %%====================================================================
 
-account_headers(Headers) ->
-	account_headers(manta:default_config(), Headers).
-
 account_headers(Config=#manta_config{agent=UserAgentVal, key=Key, key_id=KeyID}, Headers) ->
 	DateVal = iolist_to_binary(httpd_util:rfc1123_date()),
 	AuthorizationVal = <<
@@ -157,16 +162,10 @@ make_path(Path0, QS0) ->
 			<< Path1/binary, $?, QS4/binary >>
 	end.
 
-prepend_account_path(Path) ->
-	prepend_account_path(manta:default_config(), Path).
-
 prepend_account_path(#manta_config{subuser=undefined, user=User}, Path) ->
 	urlencode_path(<< $/, User/binary, $/, Path/binary >>);
 prepend_account_path(#manta_config{subuser=Subuser, user=User}, Path) ->
 	urlencode_path(<< $/, User/binary, $/, Subuser/binary, $/, Path/binary >>).
-
-role_path(Path) ->
-	role_path(manta:default_config(), Path).
 
 role_path(C=#manta_config{role=undefined}, Path) ->
 	user_path(C, Path);
@@ -188,9 +187,6 @@ urlencode_path(Path) ->
 		_ ->
 			<< P1/binary, $?, Q0/binary >>
 	end.
-
-user_path(Path) ->
-	user_path(manta:default_config(), Path).
 
 user_path(#manta_config{user=User}, << $~, $~, $/, Path/binary >>) ->
 	urlencode_path(<< $/, User/binary, $/, Path/binary >>);

--- a/src/manta_job.erl
+++ b/src/manta_job.erl
@@ -14,43 +14,25 @@
 -include("manta.hrl").
 
 %% manta_handler callbacks
--export([init/3]).
--export([handle_response/2]).
--export([handle_download/2]).
--export([terminate/1]).
+-export([init/3,
+		 handle_response/2,
+		 handle_download/2,
+		 terminate/1]).
 
 %% API exports
--export([add_inputs/2]).
--export([add_inputs/3]).
--export([add_inputs/4]).
--export([cancel/1]).
--export([cancel/2]).
--export([cancel/3]).
--export([create/1]).
--export([create/2]).
--export([create/3]).
--export([end_input/1]).
--export([end_input/2]).
--export([end_input/3]).
--export([get/1]).
--export([get/2]).
--export([get/3]).
--export([get_errors/1]).
--export([get_errors/2]).
--export([get_errors/3]).
--export([get_failures/1]).
--export([get_failures/2]).
--export([get_failures/3]).
--export([get_input/1]).
--export([get_input/2]).
--export([get_input/3]).
--export([get_output/1]).
--export([get_output/2]).
--export([get_output/3]).
--export([list/0]).
--export([list/1]).
--export([list/2]).
--export([path/1]).
+-export([add_inputs/4,
+		 cancel/3,
+		 create/3,
+		 end_input/3,
+		 get/3,
+		 get_errors/3,
+		 get_failures/3,
+		 get_input/3,
+		 get_output/3,
+		 list/2,
+		 path/1]).
+
+-ignore_xref({path,1}).
 
 -define(MAX_LIMIT, 1000).
 
@@ -170,12 +152,6 @@ terminate(#state{default=Default}) ->
 %% API functions
 %%====================================================================
 
-add_inputs(JobPath, Inputs) ->
-	?MODULE:add_inputs(JobPath, Inputs, []).
-
-add_inputs(JobPath, Inputs, Options) ->
-	?MODULE:add_inputs(manta:default_config(), JobPath, Inputs, Options).
-
 add_inputs(Config=#manta_config{}, JobPath, Inputs, Opts0) ->
 	{Headers0, Opts1} = manta:take_value(headers, Opts0, []),
 	{Timeout, Opts2} = manta:take_value(timeout, Opts1, Config#manta_config.timeout),
@@ -187,23 +163,11 @@ add_inputs(Config=#manta_config{}, JobPath, Inputs, Opts0) ->
 	],
 	manta_httpc:request(Config, Path, post, Headers1, Body, Timeout, Opts2).
 
-cancel(JobPath) ->
-	?MODULE:cancel(JobPath, []).
-
-cancel(JobPath, Options) ->
-	?MODULE:cancel(manta:default_config(), JobPath, Options).
-
 cancel(Config=#manta_config{}, JobPath, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
 	{Timeout, Opts2} = manta:take_value(timeout, Opts1, Config#manta_config.timeout),
 	Path = << (path(JobPath))/binary, "/live/cancel" >>,
 	manta_httpc:request(Config, Path, post, Headers, [], Timeout, Opts2).
-
-create(Job) ->
-	?MODULE:create(Job, []).
-
-create(Job, Options) ->
-	?MODULE:create(manta:default_config(), Job, Options).
 
 create(Config=#manta_config{}, Job, Opts0) ->
 	{Headers0, Opts1} = manta:take_value(headers, Opts0, []),
@@ -216,23 +180,11 @@ create(Config=#manta_config{}, Job, Opts0) ->
 	],
 	manta_httpc:request(Config, Path, post, Headers1, Body, Timeout, Opts2).
 
-end_input(JobPath) ->
-	?MODULE:end_input(JobPath, []).
-
-end_input(JobPath, Options) ->
-	?MODULE:end_input(manta:default_config(), JobPath, Options).
-
 end_input(Config=#manta_config{}, JobPath, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
 	{Timeout, Opts2} = manta:take_value(timeout, Opts1, Config#manta_config.timeout),
 	Path = << (path(JobPath))/binary, "/live/in/end" >>,
 	manta_httpc:request(Config, Path, post, Headers, [], Timeout, Opts2).
-
-get(JobPath) ->
-	?MODULE:get(JobPath, []).
-
-get(JobPath, Options) ->
-	?MODULE:get(manta:default_config(), JobPath, Options).
 
 get(Config=#manta_config{}, JobPath, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
@@ -240,23 +192,11 @@ get(Config=#manta_config{}, JobPath, Opts0) ->
 	Path = << (path(JobPath))/binary, "/live/status" >>,
 	manta_httpc:request(Config, Path, get, Headers, [], Timeout, Opts2).
 
-get_errors(JobPath) ->
-	?MODULE:get_errors(JobPath, []).
-
-get_errors(JobPath, Options) ->
-	?MODULE:get_errors(manta:default_config(), JobPath, Options).
-
 get_errors(Config=#manta_config{}, JobPath, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
 	{Timeout, Opts2} = manta:take_value(timeout, Opts1, Config#manta_config.timeout),
 	Path = << (path(JobPath))/binary, "/live/err" >>,
 	manta_httpc:request(Config, Path, get, Headers, [], Timeout, Opts2).
-
-get_failures(JobPath) ->
-	?MODULE:get_failures(JobPath, []).
-
-get_failures(JobPath, Options) ->
-	?MODULE:get_failures(manta:default_config(), JobPath, Options).
 
 get_failures(Config=#manta_config{}, JobPath, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
@@ -264,35 +204,17 @@ get_failures(Config=#manta_config{}, JobPath, Opts0) ->
 	Path = << (path(JobPath))/binary, "/live/fail" >>,
 	manta_httpc:request(Config, Path, get, Headers, [], Timeout, Opts2).
 
-get_input(JobPath) ->
-	?MODULE:get_input(JobPath, []).
-
-get_input(JobPath, Options) ->
-	?MODULE:get_input(manta:default_config(), JobPath, Options).
-
 get_input(Config=#manta_config{}, JobPath, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
 	{Timeout, Opts2} = manta:take_value(timeout, Opts1, Config#manta_config.timeout),
 	Path = << (path(JobPath))/binary, "/live/in" >>,
 	manta_httpc:request(Config, Path, get, Headers, [], Timeout, Opts2).
 
-get_output(JobPath) ->
-	?MODULE:get_output(JobPath, []).
-
-get_output(JobPath, Options) ->
-	?MODULE:get_output(manta:default_config(), JobPath, Options).
-
 get_output(Config=#manta_config{}, JobPath, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
 	{Timeout, Opts2} = manta:take_value(timeout, Opts1, Config#manta_config.timeout),
 	Path = << (path(JobPath))/binary, "/live/out" >>,
 	manta_httpc:request(Config, Path, get, Headers, [], Timeout, Opts2).
-
-list() ->
-	?MODULE:list([]).
-
-list(Options) ->
-	?MODULE:list(manta:default_config(), Options).
 
 list(Config=#manta_config{}, Opts0) ->
 	{Limit, Opts1} = manta:take_value(limit, Opts0, ?MAX_LIMIT),

--- a/src/manta_json_stream.erl
+++ b/src/manta_json_stream.erl
@@ -13,12 +13,14 @@
 -include("manta.hrl").
 
 %% API exports
--export([decode/1]).
--export([decode/2]).
+-export([decode/1,
+		 decode/2]).
+
+-ignore_xref({decode,1}).
 
 %% Internal
--export([error_handler/3]).
--export([incomplete_handler/3]).
+-export([error_handler/3,
+		 incomplete_handler/3]).
 
 %%====================================================================
 %% API functions

--- a/src/manta_object.erl
+++ b/src/manta_object.erl
@@ -13,37 +13,17 @@
 -include("manta.hrl").
 
 %% API exports
--export([delete/1]).
--export([delete/2]).
--export([delete/3]).
--export([get/1]).
--export([get/2]).
--export([get/3]).
--export([head/1]).
--export([head/2]).
--export([head/3]).
--export([path/1]).
--export([path/2]).
--export([path/3]).
--export([put/2]).
--export([put/3]).
--export([put/4]).
--export([put_metadata/2]).
--export([put_metadata/3]).
--export([put_metadata/4]).
--export([url/1]).
--export([url/2]).
--export([url/3]).
+-export([delete/3,
+		 get/3,
+		 head/3,
+		 path/3,
+		 put/4,
+		 put_metadata/4,
+		 url/3]).
 
 %%====================================================================
 %% API functions
 %%====================================================================
-
-delete(Pathname) ->
-	?MODULE:delete(Pathname, []).
-
-delete(Pathname, Options) ->
-	?MODULE:delete(manta:default_config(), Pathname, Options).
 
 delete(Config=#manta_config{}, Pathname, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
@@ -51,23 +31,11 @@ delete(Config=#manta_config{}, Pathname, Opts0) ->
 	Path = manta_httpc:make_path(Pathname, []),
 	manta_httpc:request(Config, Path, delete, Headers, [], Timeout, Opts2).
 
-get(Pathname) ->
-	?MODULE:get(Pathname, []).
-
-get(Pathname, Options) ->
-	?MODULE:get(manta:default_config(), Pathname, Options).
-
 get(Config=#manta_config{}, Pathname, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
 	{Timeout, Opts2} = manta:take_value(timeout, Opts1, Config#manta_config.timeout),
 	Path = manta_httpc:make_path(Pathname, []),
 	manta_httpc:request(Config, Path, get, Headers, [], Timeout, Opts2).
-
-head(Pathname) ->
-	?MODULE:head(Pathname, []).
-
-head(Pathname, Options) ->
-	?MODULE:head(manta:default_config(), Pathname, Options).
 
 head(Config=#manta_config{}, Pathname, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
@@ -75,32 +43,14 @@ head(Config=#manta_config{}, Pathname, Opts0) ->
 	Path = manta_httpc:make_path(Pathname, []),
 	manta_httpc:request(Config, Path, head, Headers, [], Timeout, Opts2).
 
-path(Pathname) ->
-	?MODULE:path(manta:default_config(), Pathname, []).
-
-path(Pathname, QueryString) ->
-	?MODULE:path(manta:default_config(), Pathname, QueryString).
-
 path(Config=#manta_config{}, Pathname, QueryString) ->
 	manta_httpc:user_path(Config, Pathname, QueryString).
-
-put(Pathname, Body) ->
-	?MODULE:put(Pathname, Body, []).
-
-put(Pathname, Body, Options) ->
-	?MODULE:put(manta:default_config(), Pathname, Body, Options).
 
 put(Config=#manta_config{}, Pathname, Body, Opts0) ->
 	{Headers, Opts1} = manta:take_value(headers, Opts0, []),
 	{Timeout, Opts2} = manta:take_value(timeout, Opts1, Config#manta_config.timeout),
 	Path = manta_httpc:make_path(Pathname, []),
 	manta_httpc:request(Config, Path, put, Headers, Body, Timeout, Opts2).
-
-put_metadata(Pathname, Metadata) ->
-	?MODULE:put_metadata(Pathname, Metadata, []).
-
-put_metadata(Pathname, Metadata, Options) ->
-	?MODULE:put_metadata(manta:default_config(), Pathname, Metadata, Options).
 
 put_metadata(Config=#manta_config{}, Pathname, Metadata, Opts0) ->
 	{Headers0, Opts1} = manta:take_value(headers, Opts0, []),
@@ -122,12 +72,6 @@ put_metadata(Config=#manta_config{}, Pathname, Metadata, Opts0) ->
 					RequestError
 			end
 	end.
-
-url(Pathname) ->
-	?MODULE:url(manta:default_config(), Pathname, []).
-
-url(Pathname, QueryString) ->
-	?MODULE:url(manta:default_config(), Pathname, QueryString).
 
 url(Config=#manta_config{url=BaseURL}, Pathname, QueryString) ->
 	<< BaseURL/binary, (?MODULE:path(Config, Pathname, QueryString))/binary >>.

--- a/src/manta_private_key.erl
+++ b/src/manta_private_key.erl
@@ -13,16 +13,22 @@
 -include_lib("public_key/include/public_key.hrl").
 
 %% API exports
--export([decode/1]).
--export([decode/2]).
--export([decode_file/1]).
--export([decode_file/2]).
--export([encode/1]).
--export([encode/2]).
--export([fingerprint/1]).
--export([public/1]).
--export([sign/2]).
--export([sign_algorithm/1]).
+-export([decode/1,
+		 decode/2,
+		 decode_file/1,
+		 decode_file/2,
+		 encode/1,
+		 encode/2,
+		 fingerprint/1,
+		 public/1,
+		 sign/2,
+		 sign_algorithm/1]).
+
+-ignore_xref({decode,1}).
+-ignore_xref({decode,2}).
+-ignore_xref({encode,1}).
+-ignore_xref({encode,2}).
+-ignore_xref({public,1}).
 
 %%====================================================================
 %% API functions

--- a/src/manta_public_key.erl
+++ b/src/manta_public_key.erl
@@ -13,10 +13,14 @@
 -include_lib("public_key/include/public_key.hrl").
 
 %% API exports
--export([decode/1]).
--export([decode_file/1]).
--export([encode/1]).
--export([fingerprint/1]).
+-export([decode/1,
+		 decode_file/1,
+		 encode/1,
+		 fingerprint/1]).
+
+-ignore_xref({decode,1}).
+-ignore_xref({decode_file,1}).
+-ignore_xref({encode,1}).
 
 -define(INLINE_INT2HEX(Int),
 	case Int of

--- a/src/manta_snaplink.erl
+++ b/src/manta_snaplink.erl
@@ -13,9 +13,11 @@
 -include("manta.hrl").
 
 %% API exports
--export([put/2]).
--export([put/3]).
--export([put/4]).
+-export([put/2,
+		 put/3,
+		 put/4]).
+
+-ignore_xref({put,2}).
 
 %%====================================================================
 %% API functions


### PR DESCRIPTION
The `xref` output is not currently clean, mostly due to the user-facing API functions. Address the output as appropriate and incorporate `xref` into the CI.